### PR TITLE
feat(page-job-scheduler): endpoint para o sample

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { MenusModule } from './menus/menus.module';
 import { MessagesModule } from './messages/messages.module';
 import { UsersModule } from './users/users.module';
 import { FavoriteModule } from './favorite/favorite.module';
+import { SchedulerModule } from './scheduler/scheduler.module';
 
 @Module({
   imports: [
@@ -12,7 +13,8 @@ import { FavoriteModule } from './favorite/favorite.module';
     HeroesModule,
     MenusModule,
     MessagesModule,
-    UsersModule
+    UsersModule,
+    SchedulerModule
   ]
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,10 +5,13 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  app.setGlobalPrefix('v1');
+
   const options = new DocumentBuilder()
     .setTitle('Portinari')
     .setDescription('Portinari Samples API')
     .setVersion('1.0')
+    .setBasePath('/v1')
     .addTag('Samples')
     .build();
   const document = SwaggerModule.createDocument(app, options);

--- a/src/scheduler/dto/create-scheduler.dto.ts
+++ b/src/scheduler/dto/create-scheduler.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateSchedulerDto {
+
+  @ApiPropertyOptional()
+  daily: { hour: number, minute: number };
+
+  @ApiPropertyOptional()
+  executionParameter: object;
+
+  @ApiPropertyOptional()
+  firstExecution: string;
+
+  @ApiPropertyOptional()
+  monthly: { day: number, hour: number, minute: number };
+
+  @ApiProperty()
+  processID: string;
+
+  @ApiPropertyOptional()
+  recurrent: boolean;
+
+  @ApiPropertyOptional()
+  weekly: { daysOfWeek: Array<string>, hour: number, minute: number };
+
+}

--- a/src/scheduler/process/dto/create-parameter.dto.ts
+++ b/src/scheduler/process/dto/create-parameter.dto.ts
@@ -1,0 +1,101 @@
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
+
+export class CreateParameterDto {
+
+  @ApiPropertyOptional()
+  columns: Array<any>;
+
+  @ApiPropertyOptional()
+  required: boolean;
+
+  @ApiPropertyOptional()
+  optional: boolean;
+
+  @ApiPropertyOptional()
+  options: Array<{ label: string, value: string | number }>;
+
+  @ApiPropertyOptional()
+  optionsMulti: boolean;
+
+  @ApiPropertyOptional()
+  optionsService: string;
+
+  @ApiPropertyOptional()
+  searchService: string;
+
+  @ApiPropertyOptional()
+  mask: string;
+
+  @ApiPropertyOptional()
+  pattern: string;
+
+  @ApiPropertyOptional()
+  minLength: number;
+
+  @ApiPropertyOptional()
+  maxLength: number;
+
+  @ApiPropertyOptional()
+  disabled: boolean;
+
+  @ApiPropertyOptional()
+  help: string;
+
+  @ApiPropertyOptional()
+  booleanTrue: string;
+
+  @ApiPropertyOptional()
+  booleanFalse: string;
+
+  @ApiPropertyOptional()
+  maxValue: string | number;
+
+  @ApiPropertyOptional()
+  minValue: string | number;
+
+  @ApiPropertyOptional()
+  rows: number;
+
+  @ApiPropertyOptional()
+  secret: boolean;
+
+  @ApiPropertyOptional()
+  params: any;
+
+  @ApiPropertyOptional()
+  errorMessage: string;
+
+  @ApiPropertyOptional()
+  key: boolean;
+
+  @ApiProperty()
+  property: string;
+
+  @ApiPropertyOptional()
+  label: string;
+
+  @ApiPropertyOptional()
+  gridColumns: number;
+
+  @ApiPropertyOptional()
+  gridSmColumns: number;
+
+  @ApiPropertyOptional()
+  gridMdColumns: number;
+
+  @ApiPropertyOptional()
+  gridLgColumns: number;
+
+  @ApiPropertyOptional()
+  gridXlColumns: number;
+
+  @ApiPropertyOptional()
+  visible: boolean;
+
+  @ApiPropertyOptional()
+  divider: string;
+
+  @ApiPropertyOptional()
+  type: string;
+
+}

--- a/src/scheduler/process/dto/create-process.dto.ts
+++ b/src/scheduler/process/dto/create-process.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateProcessDto {
+
+  @ApiProperty()
+  processID: string;
+
+  @ApiProperty()
+  description: string;
+
+}

--- a/src/scheduler/process/dto/get-processes.dto.ts
+++ b/src/scheduler/process/dto/get-processes.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { CreateProcessDto } from './create-process.dto';
+
+export class GetProcessesDto {
+
+  @ApiProperty({
+    type: () => [CreateProcessDto],
+  })
+  items: Array<CreateProcessDto>;
+
+}

--- a/src/scheduler/process/processes.controller.ts
+++ b/src/scheduler/process/processes.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Query, Param } from '@nestjs/common';
+import { ApiTags, ApiQuery, ApiResponse, ApiParam } from '@nestjs/swagger';
+
+import { ProcessesService } from './processes.service';
+import { CreateProcessDto } from './dto/create-process.dto';
+import { GetProcessesDto } from './dto/get-processes.dto';
+import { CreateParameterDto } from './dto/create-parameter.dto';
+
+@ApiTags('processes')
+@Controller('scheduler/processes')
+export class ProcessesController {
+
+  constructor(private processService: ProcessesService) {}
+
+  @ApiResponse({ status: 200, type: GetProcessesDto })
+  @ApiQuery({ name: 'search', required: false })
+  @Get()
+  getProcesses(@Query() query) {
+    return query['search'] ?
+      this.processService.filterProcesses(query['search'])
+      : this.processService.getProcesses();
+  }
+
+  @ApiResponse({ status: 200, type: CreateProcessDto })
+  @ApiParam({ name: 'id' })
+  @Get(':id')
+  getProcess(@Param() params) {
+    return this.processService.getProcess(params['id']);
+  }
+
+  @ApiResponse({ status: 200, type: [CreateParameterDto] })
+  @ApiParam({ name: 'id' })
+  @Get(':id/parameters')
+  getParametersByProcesses(@Param() params) {
+    return this.processService.getParametersByProcess(params['id']);
+  }
+
+}

--- a/src/scheduler/process/processes.data.ts
+++ b/src/scheduler/process/processes.data.ts
@@ -1,0 +1,83 @@
+export const processes = [
+  { processID: 'process1', description: 'Release new version' },
+  { processID: 'process2', description: 'Run E2E tests' },
+  { processID: 'process3', description: 'Run build' },
+  { processID: 'process4', description: 'Update portinari-portal' },
+  { processID: 'process5', description: 'Clear sample database' },
+];
+
+export const parameters = {
+  process1: [
+    {
+      property: 'version',
+      required: true,
+      gridLgColumns: '6',
+      gridXlColumns: '6',
+      divider: 'Package information'
+    },
+    {
+      property: 'packages',
+      label: 'Packages to upgrade',
+      optionsMulti: true,
+      gridLgColumns: '6',
+      gridXlColumns: '6',
+      options: [
+        { value: 'ui' },
+        { value: 'templates' },
+        { value: 'sync' },
+        { value: 'storage' },
+        { value: 'code-editor' },
+      ]
+    },
+    {
+      property: 'user',
+      divider: 'NPM Credentials',
+      gridXlColumns: '6',
+      gridLgColumns: '6'
+    },
+    {
+      property: 'password',
+      secret: true,
+      gridXlColumns: '6',
+      gridLgColumns: '6'
+    },
+  ],
+  process2: [
+    {
+      property: 'packages',
+      label: 'Packages to validate',
+      optionsMulti: true,
+      gridLgColumns: '6',
+      gridXlColumns: '6',
+      options: [
+        { value: 'ui' },
+        { value: 'templates' },
+        { value: 'sync' },
+        { value: 'storage' },
+        { value: 'code-editor' },
+      ]
+    },
+  ],
+  process3: [
+    {
+      property: 'options',
+      label: 'Additional customization',
+      gridLgColumns: '12', gridXlColumns: '12',
+      optionsMulti: true,
+      options: [
+        { value: 'installDependencies', label: 'Install dependencies' },
+        { value: 'unitTest', label: 'Run unit tests' },
+        { value: 'lint', label: 'Run lint' }
+      ]
+    }
+  ],
+  process4: [
+    {
+      property: 'version',
+      required: true,
+      gridLgColumns: '6',
+      gridXlColumns: '6'
+    }
+  ],
+  process5: []
+};

--- a/src/scheduler/process/processes.service.ts
+++ b/src/scheduler/process/processes.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+
+import { processes, parameters } from './processes.data';
+
+@Injectable()
+export class ProcessesService {
+
+  getProcess(processId: string) {
+    return processes.find(process => process.processID === processId);
+  }
+
+  getProcesses() {
+    return {
+      items: processes
+    };
+  }
+
+  filterProcesses(label: string) {
+    const filter = label.toLowerCase().trim();
+
+    const filteredProcesses = processes.filter(process =>
+      process.description.toLowerCase().includes(filter) ||
+      process.processID.toLowerCase().includes(filter)
+    );
+
+    return {
+      items: filteredProcesses
+    };
+  }
+
+  getParametersByProcess(processId) {
+    return {
+      items: parameters[processId]
+    };
+  }
+
+}

--- a/src/scheduler/scheduler.controller.ts
+++ b/src/scheduler/scheduler.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiBody } from '@nestjs/swagger';
+
+import { SchedulerService } from './scheduler.service';
+import { CreateSchedulerDto } from './dto/create-scheduler.dto';
+
+@ApiTags('scheduler')
+@Controller('scheduler')
+export class SchedulerController {
+
+  constructor(private schedulerService: SchedulerService) {}
+
+  @ApiBody({ type: CreateSchedulerDto })
+  @Post()
+  createScheduler(@Body() newScheduler: CreateSchedulerDto) {
+    this.schedulerService.createScheduler(newScheduler);
+  }
+
+}

--- a/src/scheduler/scheduler.data.ts
+++ b/src/scheduler/scheduler.data.ts
@@ -1,0 +1,13 @@
+import { Scheduler } from './scheduler.interface';
+
+export const schedules: Array<Scheduler> = [
+  {
+    firstExecution: '2020-02-26T09:30:00-03:00',
+    recurrent: false,
+    executionParameter: {
+      version: '1.22.0',
+      packages: ['ui']
+    },
+    processID: 'process1'
+  }
+];

--- a/src/scheduler/scheduler.interface.ts
+++ b/src/scheduler/scheduler.interface.ts
@@ -1,0 +1,17 @@
+export interface Scheduler {
+
+  daily?: { hour: number, minute: number };
+
+  executionParameter?: object;
+
+  firstExecution?: string;
+
+  monthly?: { day: number, hour: number, minute: number };
+
+  processID: string;
+
+  recurrent?: boolean;
+
+  weekly?: { daysOfWeek: Array<string>, hour: number, minute: number };
+
+}

--- a/src/scheduler/scheduler.module.ts
+++ b/src/scheduler/scheduler.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { SchedulerController } from './scheduler.controller';
+import { SchedulerService } from './scheduler.service';
+import { ProcessesController } from './process/processes.controller';
+import { ProcessesService } from './process/processes.service';
+
+@Module({
+  controllers: [SchedulerController, ProcessesController],
+  providers: [SchedulerService, ProcessesService]
+})
+export class SchedulerModule {}

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+
+import { schedules } from './scheduler.data';
+import { CreateSchedulerDto } from './dto/create-scheduler.dto';
+
+@Injectable()
+export class SchedulerService {
+
+  createScheduler(scheduler: CreateSchedulerDto) {
+    schedules.push(scheduler);
+  }
+
+}


### PR DESCRIPTION
**Sample Page Job Scheduler**

- Criação dos endpoints para o sample do Page Job Scheduler.

- Adicionado documentação do Swagger para os novos endpoints

- Adicionado prefixo "v1" em todos os endpoints.

Fixes DTHFUI-2161

Simulação:
- npm run start:dev
- http://localhost:3000/api